### PR TITLE
chore(build): provided jackson

### DIFF
--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -43,7 +43,7 @@ dependencies {
   compile 'com.android.support:appcompat-v7:25.2.0'
   compile 'com.android.support:support-annotations:25.2.0'
   compile 'com.android.support:design:25.2.0'
-  compile 'com.fasterxml.jackson.core:jackson-databind:2.8.3'
+  provided 'com.fasterxml.jackson.core:jackson-databind:2.8.3'
   compile 'com.facebook.fresco:fresco:1.0.1'
   compile 'com.facebook.fresco:imagepipeline-okhttp3:1.0.1'
   provided 'com.facebook.react:react-native:+'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loggi/native-navigation",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Native Navigation for React Native",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
React Native já inclui `jackson.core`. Essa alteração evita que o gradle fique reclamando que há 2 libs iguais em tempo de build.