### PR TITLE
fix(backstack): fix backstack being empty

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinator.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinator.java
@@ -109,6 +109,9 @@ public class ScreenCoordinator {
       ft.setCustomAnimations(anim.enter, anim.exit, anim.popEnter, anim.popExit);
     }
     BackStack bsi = getCurrentBackStack();
+    if (bsi == null) {
+      return;
+    }
     ft
             .detach(currentFragment)
             .add(container.getId(), fragment)
@@ -209,6 +212,9 @@ public class ScreenCoordinator {
 
   public void pop() {
     BackStack bsi = getCurrentBackStack();
+    if (bsi == null) {
+      return;
+    }
     if (bsi.getSize() == 1) {
       dismiss();
       return;
@@ -281,7 +287,10 @@ public class ScreenCoordinator {
   }
 
   private BackStack getCurrentBackStack() {
-    return backStacks.peek();
+    if (backStacks.size() > 0) {
+      return backStacks.peek();
+    }
+    return null;
   }
 
   @NonNull

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loggi/native-navigation",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Native Navigation for React Native",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Conserta um crash que acontecia ao tentar dar um `pop` na navegação. Exemplo do crash: https://fabric.io/loggi/android/apps/com.loggi.driverapp/issues/59ba7842be077a4dcc9ce7f2?time=last-ninety-days