### PR TITLE
Don't throw an exception when ensure Activity fails

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/NavigatorModule.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/NavigatorModule.java
@@ -97,11 +97,13 @@ class NavigatorModule extends ReactContextBaseJavaModule {
         if (activity == null) {
           return;
         }
-        ensureCoordinatorComponent(activity);
-        ((ScreenCoordinatorComponent) activity).getScreenCoordinator().pushScreen(
-            screenName,
-            ConversionUtil.toBundle(props),
-            ConversionUtil.toBundle(options));
+
+        if (isCoordinatorComponent(activity)) {
+          ((ScreenCoordinatorComponent) activity).getScreenCoordinator().pushScreen(
+                  screenName,
+                  ConversionUtil.toBundle(props),
+                  ConversionUtil.toBundle(options));
+        }
       }
     });
   }
@@ -127,12 +129,13 @@ class NavigatorModule extends ReactContextBaseJavaModule {
         if (activity == null) {
           return;
         }
-        ensureCoordinatorComponent(activity);
+        if (isCoordinatorComponent(activity)) {
           ((ScreenCoordinatorComponent) activity).getScreenCoordinator().presentScreen(
-            screenName,
-            ConversionUtil.toBundle(props),
-            ConversionUtil.toBundle(options),
-            promise);
+                  screenName,
+                  ConversionUtil.toBundle(props),
+                  ConversionUtil.toBundle(options),
+                  promise);
+        }
       }
     });
   }
@@ -158,8 +161,10 @@ class NavigatorModule extends ReactContextBaseJavaModule {
         if (activity == null) {
           return;
         }
-        ensureCoordinatorComponent(activity);
-        ((ScreenCoordinatorComponent) activity).getScreenCoordinator().dismiss(Activity.RESULT_OK, payloadToMap(payload));
+
+        if (isCoordinatorComponent(activity)) {
+          ((ScreenCoordinatorComponent) activity).getScreenCoordinator().dismiss(Activity.RESULT_OK, payloadToMap(payload));
+        }
       }
     });
   }
@@ -175,8 +180,10 @@ class NavigatorModule extends ReactContextBaseJavaModule {
         if (activity == null) {
           return;
         }
-        ensureCoordinatorComponent(activity);
-        ((ScreenCoordinatorComponent) activity).getScreenCoordinator().pop();
+
+        if (isCoordinatorComponent(activity)) {
+          ((ScreenCoordinatorComponent) activity).getScreenCoordinator().pop();
+        }
       }
     });
   }
@@ -222,10 +229,8 @@ class NavigatorModule extends ReactContextBaseJavaModule {
     activity.finish();
   }
 
-  private void ensureCoordinatorComponent(Activity activity) {
-    if (!(activity instanceof ScreenCoordinatorComponent)) {
-      throw new IllegalStateException("Your activity must implement ScreenCoordinatorComponent.");
-    }
+  private boolean isCoordinatorComponent(Activity activity) {
+    return activity instanceof ScreenCoordinatorComponent;
   }
 
   /**

--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/NavigatorModule.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/NavigatorModule.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.Nullable;
+import android.util.Log;
 
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -26,6 +27,7 @@ class NavigatorModule extends ReactContextBaseJavaModule {
 
   private static final String CLOSE_BEHAVIOR_DISMISS = "dismiss";
   private static final String RESULT_CODE = "resultCode";
+  private static final String TAG = NavigatorModule.class.getSimpleName();
   private final Handler handler = new Handler(Looper.getMainLooper());
   private final ReactNavigationCoordinator coordinator;
 
@@ -230,7 +232,12 @@ class NavigatorModule extends ReactContextBaseJavaModule {
   }
 
   private boolean isCoordinatorComponent(Activity activity) {
-    return activity instanceof ScreenCoordinatorComponent;
+    if (activity instanceof ScreenCoordinatorComponent) {
+      return true;
+    } else {
+      Log.w(TAG, "Activity is not a ScreenCoordinatorComponent.");
+      return false;
+    }
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loggi/native-navigation",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Native Navigation for React Native",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Sobre a tarefa

Atualmente, o método `ensureComponentActivity` verifica se a Activity atual é uma instância de `ScreenCoordinatorComponent`. Caso não seja, ela lança uma exception. O problema é que essa exception não é capturada por ninguém, fazendo o app crashar.

Ao invés de fazer um `throw`, transformamos esse método em um check simples. Caso ele falhe, apenas logamos um warning no log. Como isso também muda um pouco a ideia do método, coube uma mudança de nome para `isCoordinatorComponent`.

## Sobre o crash

Esse crash acontece porque eventos de navegação são assíncronos no Android. Na hora do teste do `ensure...`, pode ser que o usuário já tenha navegado para outra Activity que não é mais uma `ScreenCoordinatorActivity`, fazendo com que a exception seja lançada sem necessidade.